### PR TITLE
fix: align about.ts to golden standard Section 4.9

### DIFF
--- a/src/tools/about.ts
+++ b/src/tools/about.ts
@@ -1,42 +1,15 @@
+/**
+ * about — Server metadata, dataset statistics, and provenance.
+ */
+
 import type Database from '@ansvar/mcp-sqlite';
-import {
-  PACKAGE_NAME,
-  REPOSITORY_URL,
-  SERVER_LABEL,
-} from '../constants.js';
+import { detectCapabilities, readDbMetadata } from '../capabilities.js';
+import { SERVER_NAME, SERVER_VERSION, REPOSITORY_URL } from '../constants.js';
 
 export interface AboutContext {
   version: string;
   fingerprint: string;
   dbBuilt: string;
-}
-
-export interface AboutResult {
-  server: {
-    name: string;
-    package: string;
-    version: string;
-    suite: string;
-    repository: string;
-  };
-  dataset: {
-    fingerprint: string;
-    built: string;
-    jurisdiction: string;
-    content_basis: string;
-    counts: Record<string, number>;
-  };
-  provenance: {
-    sources: string[];
-    license: string;
-    authenticity_note: string;
-  };
-  security: {
-    access_model: string;
-    network_access: boolean;
-    filesystem_access: boolean;
-    arbitrary_code: boolean;
-  };
 }
 
 function safeCount(db: InstanceType<typeof Database>, sql: string): number {
@@ -48,48 +21,45 @@ function safeCount(db: InstanceType<typeof Database>, sql: string): number {
   }
 }
 
-export function getAbout(
-  db: InstanceType<typeof Database>,
-  context: AboutContext
-): AboutResult {
+export function getAbout(db: InstanceType<typeof Database>, context: AboutContext) {
+  const caps = detectCapabilities(db);
+  const meta = readDbMetadata(db);
+
+  const euRefs = safeCount(db, 'SELECT COUNT(*) as count FROM eu_references');
+
+  const stats: Record<string, number> = {
+    documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
+    provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
+    definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
+  };
+
+  if (euRefs > 0) {
+    stats.eu_documents = safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents');
+    stats.eu_references = euRefs;
+  }
+
   return {
-    server: {
-      name: SERVER_LABEL,
-      package: PACKAGE_NAME,
-      version: context.version,
-      suite: 'Ansvar Compliance Suite',
-      repository: REPOSITORY_URL,
-    },
-    dataset: {
-      fingerprint: context.fingerprint,
-      built: context.dbBuilt,
-      jurisdiction: 'Belgium (BE)',
-      content_basis:
-        'Belgian statute text from Justel open data. ' +
-        'Covers cybersecurity, data protection, and related legislation.',
-      counts: {
-        legal_documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
-        legal_provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
-        eu_documents: safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents'),
-        eu_references: safeCount(db, 'SELECT COUNT(*) as count FROM eu_references'),
+    name: 'Belgian Law MCP',
+    version: context.version,
+    jurisdiction: 'BE',
+    description: 'Belgian Law MCP — legislation via Model Context Protocol',
+    stats,
+    data_sources: [
+      {
+        name: 'Belgian Official Gazette (Moniteur Belge)',
+        url: 'https://www.ejustice.just.fgov.be',
+        authority: 'FPS Justice',
       },
+    ],
+    freshness: {
+      database_built: context.dbBuilt,
     },
-    provenance: {
-      sources: [
-        'Justel (statutes, statutory instruments)',
-        'EUR-Lex (EU directive references)',
-      ],
-      license:
-        'Apache-2.0 (server code). Legal source texts under Government open data.',
-      authenticity_note:
-        'Statute text is derived from Justel open data. ' +
-        'Verify against official publications when legal certainty is required.',
-    },
-    security: {
-      access_model: 'read-only',
-      network_access: false,
-      filesystem_access: false,
-      arbitrary_code: false,
+    disclaimer:
+      'This is a research tool, not legal advice. Verify critical citations against official sources.',
+    network: {
+      name: 'Ansvar MCP Network',
+      open_law: 'https://ansvar.eu/open-law',
+      directory: 'https://ansvar.ai/mcp',
     },
   };
 }


### PR DESCRIPTION
## Summary
- Fixes jurisdiction metadata contamination
- Adds disclaimer, freshness, network blocks per golden standard Section 4.9
- Uses data_sources array with correct source name, URL, authority

## Quality checks fixed
- **Q16** — jurisdiction metadata now correct (BE)
- **Q25** — disclaimer present
- **Q23** — freshness block present

Generated by scripts/fleet-fix-about.sh