### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -13,6 +13,7 @@ export interface GetProvisionInput {
   chapter?: string;
   section?: string;
   provision_ref?: string;
+  article?: string;
   as_of_date?: string;
 }
 
@@ -53,7 +54,7 @@ export async function getProvision(
   const resolvedDocumentId = resolveExistingStatuteId(db, input.document_id) ?? input.document_id;
   const asOfDate = normalizeAsOfDate(input.as_of_date);
 
-  const provisionRef = input.provision_ref ?? input.section;
+  const provisionRef = input.provision_ref ?? input.section ?? input.article;
 
   // If no specific provision, return all provisions for the document
   if (!provisionRef) {


### PR DESCRIPTION
## Summary

- Adds `article?: string` to `GetProvisionInput` interface in `src/tools/get-provision.ts`
- Updates provision reference resolution to `input.provision_ref ?? input.section ?? input.article`

## Problem

The fleet audit test sends `{"document_id": "...", "article": "1"}` but the tool only accepted `section` and `provision_ref`. The `article` field was silently ignored, causing the tool to return all provisions instead of the specific one requested.

## Test plan

- [x] No new test failures introduced (pre-existing build error in search-case-law.ts is unrelated)
- [x] Verified on dev branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)