### PR TITLE
chore: propagate codex health-test skipif fix from dev to main

### DIFF
--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import handler from '../../api/health.js';
+
+// The health handler returns `status: 'ok'` only when the backing SQLite DB
+// is reachable. In CI the DB is built before tests; in local developer
+// environments it may be absent (gitignored). When absent, the handler
+// returns `status: 'degraded'` with zero counts — this is expected and must
+// not cause a test failure.
+const DB_PATH = join(process.cwd(), 'data', 'database.db');
+const HAS_DB = existsSync(DB_PATH);
 
 interface MockResponse {
   statusCode: number;
@@ -48,10 +58,16 @@ describe('api/health', () => {
     handler(createRequest('/health'), res);
 
     expect(state.statusCode).toBe(200);
-    expect(state.body).toMatchObject({
-      status: 'ok',
-      server: 'belgian-legal-citations',
-    });
+    const body = state.body as { status: string; server: string };
+    expect(body.server).toBe('belgian-legal-citations');
+
+    if (HAS_DB) {
+      // When DB is present (CI), the handler should report healthy data.
+      expect(body.status).toBe('ok');
+    } else {
+      // When DB is absent (local dev), degraded is the expected fallback.
+      expect(body.status).toBe('degraded');
+    }
   });
 
   it('returns version payload for /version', () => {


### PR DESCRIPTION
Brings PR #70 (codex's health-test tolerance fix) to main so audit re-sweep pre-flight passes.