### PR TITLE
fix(ci): adopt arch-docs PR #188 ci.yml fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   build-and-test:
@@ -26,20 +26,81 @@ jobs:
         run: npm run lint
 
       - name: Build database
-        run: npm run build:db
+        run: |
+          if jq -e '.scripts["build:db"]' package.json >/dev/null 2>&1; then
+            npm run build:db
+          else
+            echo "build:db script not present — skipping (native-curated MCP without DB build step)"
+          fi
 
       - name: Type check
-        run: npm run typecheck
+        run: |
+          if jq -e '.scripts.typecheck' package.json >/dev/null 2>&1; then
+            npm run typecheck
+          else
+            echo "typecheck script not present — skipping"
+          fi
 
       - name: Unit tests
-        run: npm test
+        run: |
+          if jq -e '.scripts.test' package.json >/dev/null 2>&1; then
+            # vitest exits 1 on "No test files found"; treat as N/A rather than failure.
+            # An MCP with a `test` script but no test files is undertested but not broken.
+            OUTPUT=$(npm test 2>&1) && EC=0 || EC=$?
+            echo "$OUTPUT"
+            if [ $EC -ne 0 ] && echo "$OUTPUT" | grep -q "No test files found"; then
+              echo "::warning::no test files in repo — treating as N/A"
+              exit 0
+            fi
+            exit $EC
+          else
+            echo "test script not present — skipping (no unit tests in this MCP)"
+          fi
 
       - name: Contract tests
-        run: npm run test:contract
+        run: |
+          if jq -e '.scripts["test:contract"]' package.json >/dev/null 2>&1; then
+            OUTPUT=$(npm run test:contract 2>&1) && EC=0 || EC=$?
+            echo "$OUTPUT"
+            if [ $EC -ne 0 ] && echo "$OUTPUT" | grep -q "No test files found"; then
+              echo "::warning::no contract test files in repo — treating as N/A"
+              exit 0
+            fi
+            exit $EC
+          else
+            echo "test:contract script not present — skipping"
+          fi
 
       - name: Database integrity
         run: |
-          sqlite3 data/database.db "PRAGMA integrity_check;" | grep -q "ok"
-          sqlite3 data/database.db "PRAGMA journal_mode;" | grep -q "delete"
+          # Detect DB path from build:db script; fall back to default.
+          DB_PATH=$(jq -r '.scripts["build:db"] // empty' package.json | grep -oE 'data/[a-zA-Z0-9_-]+\.db' | head -1)
+          DB_PATH=${DB_PATH:-data/database.db}
+          if [ -f "$DB_PATH" ]; then
+            # integrity_check is the meaningful correctness check.
+            # journal_mode is a deployment-hygiene preference; some MCPs ship WAL mode
+            # (e.g. for read-write at runtime), so don't assert delete.
+            sqlite3 "$DB_PATH" "PRAGMA integrity_check;" | grep -q "ok"
+          else
+            echo "no database file at $DB_PATH — skipping integrity check"
+          fi
+
+      - name: Coverage consistency
+        run: |
+          if jq -e '.scripts["coverage:verify"]' package.json >/dev/null 2>&1; then
+            # coverage:verify typically needs a built DB; gate on DB existence
+            # rather than just script presence (auto-ingested MCPs may have the
+            # script but no DB in CI because build:db skipped or wasn't defined).
+            DB_PATH=$(jq -r '.scripts["build:db"] // empty' package.json | grep -oE 'data/[a-zA-Z0-9_-]+\.db' | head -1)
+            DB_PATH=${DB_PATH:-data/database.db}
+            if [ -f "$DB_PATH" ]; then
+              npm run coverage:verify
+            else
+              echo "coverage:verify present but no DB at $DB_PATH — skipping (build:db did not produce one)"
+            fi
+          else
+            echo "coverage:verify script not present — skipping"
+          fi
+
       - name: Audit dependencies
         run: npm audit --audit-level=high || true


### PR DESCRIPTION
Today's audit re-sweep on this repo (via apply-mcp-standard.py) shipped the stale ci.yml because the local arch-docs template was outdated when the script ran. This PR cherry-picks the fixed ci.yml from arch-docs main:

- pull_request triggers main + dev (was main only)
- jq script-presence gates on build:db / typecheck / test / test:contract / coverage:verify
- PRAGMA journal_mode=delete assertion removed
- coverage:verify gated on DB-file existence

Same fix as STRIDE-mcp PR #71. Bootstrap caveat: this PR's CI may not trigger because the BASE (main) still has the stale ci.yml — merge with --admin and the next PR will get full CI.