### PR TITLE
fix(publish-npm): stop masking build:db failures (cherry-pick of anti-corruption-aml#15)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -69,6 +69,17 @@ jobs:
             echo "already_published=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # Probe whether this MCP has a build:db script and whether it ships
+          # a DB. The template is shared across the fleet; not every MCP has
+          # a DB. These flags let downstream steps skip cleanly without
+          # masking real failures (the previous `2>/dev/null || true` masked
+          # genuine build:db breakage and could publish a package missing
+          # data/database.db).
+          HAS_BUILD_DB=$(node -e "process.stdout.write(String(Boolean((require('./package.json').scripts || {})['build:db'])))")
+          DECLARES_DB=$(node -e "const f=require('./package.json').files||[]; process.stdout.write(String(f.some(x => x==='data/database.db' || x==='data')))")
+          echo "has_build_db=${HAS_BUILD_DB}" >> "$GITHUB_OUTPUT"
+          echo "declares_db=${DECLARES_DB}" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
         if: steps.check.outputs.already_published == 'false'
         run: npm ci
@@ -78,8 +89,17 @@ jobs:
         run: npm run build
 
       - name: Build database
-        if: steps.check.outputs.already_published == 'false'
-        run: npm run build:db 2>/dev/null || true
+        if: steps.check.outputs.already_published == 'false' && steps.check.outputs.has_build_db == 'true'
+        run: npm run build:db
+
+      - name: Verify packaged database
+        if: steps.check.outputs.already_published == 'false' && steps.check.outputs.declares_db == 'true'
+        run: |
+          if [ ! -s data/database.db ]; then
+            echo "::error::data/database.db is missing or empty after build:db; refusing to publish a package that declares it in 'files'."
+            exit 1
+          fi
+          echo "data/database.db: $(stat -c%s data/database.db) bytes"
 
       - name: Publish
         if: steps.check.outputs.already_published == 'false'


### PR DESCRIPTION
## Summary

Cherry-picks the workflow fix from [anti-corruption-aml-mcp PR #15](https://github.com/Ansvar-Systems/anti-corruption-aml-mcp/pull/15) — `.github/workflows/publish-npm.yml` had `npm run build:db 2>/dev/null || true` which discarded stderr and forced success, allowing `npm publish` to ship a package missing `data/database.db` when build:db failed.

## Why direct to main

The `dev` branch on this repo does not yet have `publish-npm.yml` at all — the audit sweep that introduced it landed direct to main. Routing through dev would mean either a no-op file-creation PR or a prior main→dev sync. PR-ing direct to main as a one-off fix.

## Changes

- `.github/workflows/publish-npm.yml`: rewritten to match the canonical template (no masking, conditional build:db, DB existence verification before publish)

## Test plan

- [ ] CI green on this PR
- [ ] Next publish run on main reports either the build:db output verbatim, or a clear error if it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)