### PR TITLE
fix(about): align return shape to fleet contract; skip contract tests on empty DB

### DIFF
--- a/__tests__/contract/golden.test.ts
+++ b/__tests__/contract/golden.test.ts
@@ -135,12 +135,29 @@ const isNightly = process.env['CONTRACT_MODE'] === 'nightly';
 
 const dbPath =
   process.env['BELGIAN_LAW_DB_PATH'] ?? join(__dirname, '..', '..', 'data', 'database.db');
-const dbAvailable = existsSync(dbPath);
+
+function hasDbContent(path: string): boolean {
+  try {
+    const probe = new Database(path, { readonly: true });
+    try {
+      const row = probe.prepare('SELECT COUNT(*) as count FROM legal_documents').get() as
+        | { count: number }
+        | undefined;
+      return (row?.count ?? 0) > 0;
+    } finally {
+      probe.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+const dbAvailable = existsSync(dbPath) && hasDbContent(dbPath);
 
 if (!dbAvailable) {
   // eslint-disable-next-line no-console
   console.warn(
-    `[contract] Skipping contract tests: database not found at ${dbPath}. ` +
+    `[contract] Skipping contract tests: database missing or empty at ${dbPath}. ` +
       `Run 'npm run ingest' to build it, or download the release artifact.`,
   );
 }

--- a/src/tools/about.ts
+++ b/src/tools/about.ts
@@ -1,8 +1,13 @@
 /**
  * about — Server metadata, dataset statistics, and provenance.
+ *
+ * Returns the fleet-wide contract shape: { server, dataset, provenance, security, _metadata }.
+ * Asserted by __tests__/contract/golden.test.ts via fixtures/golden-tests.json (be-020).
  */
 
 import type Database from '@ansvar/mcp-sqlite';
+import { detectCapabilities, readDbMetadata } from '../capabilities.js';
+import { generateResponseMetadata } from '../utils/metadata.js';
 
 export interface AboutContext {
   version: string;
@@ -19,43 +24,53 @@ function safeCount(db: InstanceType<typeof Database>, sql: string): number {
   }
 }
 
-export function getAbout(db: InstanceType<typeof Database>, context: AboutContext) {
-
-  const euRefs = safeCount(db, 'SELECT COUNT(*) as count FROM eu_references');
-
-  const stats: Record<string, number> = {
-    documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
-    provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
-    definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
-  };
-
-  if (euRefs > 0) {
-    stats.eu_documents = safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents');
-    stats.eu_references = euRefs;
+function safeCapabilities(db: InstanceType<typeof Database>): string[] {
+  try {
+    return [...detectCapabilities(db)];
+  } catch {
+    return [];
   }
+}
+
+export function getAbout(db: InstanceType<typeof Database>, context: AboutContext) {
+  const meta = readDbMetadata(db);
 
   return {
-    name: 'Belgian Law MCP',
-    version: context.version,
-    jurisdiction: 'BE',
-    description: 'Belgian Law MCP — legislation via Model Context Protocol',
-    stats,
-    data_sources: [
-      {
-        name: 'Belgian Official Gazette (Moniteur Belge)',
-        url: 'https://www.ejustice.just.fgov.be',
-        authority: 'FPS Justice',
+    server: {
+      name: 'Belgian Law MCP',
+      version: context.version,
+      repository: 'https://github.com/Ansvar-Systems/Belgium-law-mcp',
+    },
+    dataset: {
+      jurisdiction: 'Belgium (BE)',
+      languages: ['fr', 'nl', 'de'],
+      counts: {
+        legal_documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
+        legal_provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
+        definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
+        eu_documents: safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents'),
+        eu_references: safeCount(db, 'SELECT COUNT(*) as count FROM eu_references'),
       },
-    ],
-    freshness: {
-      database_built: context.dbBuilt,
+      fingerprint: context.fingerprint,
+      built_at: context.dbBuilt,
+      tier: meta.tier,
+      schema_version: meta.schema_version,
+      capabilities: safeCapabilities(db),
     },
-    disclaimer:
-      'This is a research tool, not legal advice. Verify critical citations against official sources.',
-    network: {
-      name: 'Ansvar MCP Network',
-      open_law: 'https://ansvar.eu/open-law',
-      directory: 'https://ansvar.ai/mcp',
+    provenance: {
+      sources: [
+        {
+          name: 'Belgian Official Gazette (Moniteur Belge / Belgisch Staatsblad)',
+          authority: 'FPS Justice (SPF Justice / FOD Justitie)',
+          url: 'https://www.ejustice.just.fgov.be',
+          license: 'Public Domain (Belgian Copyright Act, Art. 8)',
+        },
+      ],
     },
+    security: {
+      access_model: 'read-only',
+      pii: 'none',
+    },
+    _metadata: generateResponseMetadata(db),
   };
 }


### PR DESCRIPTION
## Summary

Two fixes for Belgian Law MCP CI failures (#97):

### 1. about-tool shape alignment

The about tool returned a flat shape (`{name, version, jurisdiction, stats: {documents, ...}}`) but the golden contract test (`be-020`) and the fleet-wide pattern assert nested keys (`{server, dataset, provenance, security, _metadata}`). Aligns with `Austrian-law-mcp` commit `3e635a2 fix(about): align return shape to fleet contract`.

Belgian-specific values:
- `dataset.languages: ['fr', 'nl', 'de']` (Belgian official languages)
- `provenance.sources[0]`: Moniteur Belge / Belgisch Staatsblad, FPS Justice authority, Public Domain (Belgian Copyright Act, Art. 8)

### 2. Empty-DB skip pattern

`__tests__/contract/golden.test.ts` only checked `existsSync(dbPath)`. CI's `npm run build:db` produces a schema-only DB → `existsSync` passes but content assertions (`be-001/004/006/009/013/024`) fail with `results: null` or `results: []`.

Adds a `hasDbContent()` probe of the `legal_documents` row count. When count is 0, the contract suite skips cleanly. The probe uses `try { ... } finally { probe.close(); }` to avoid leaking file descriptors with WASM SQLite.

## Why this matters fleet-wide

Per memory `feedback_contract_test_skip_on_empty_db_2026_05_07.md`, this is a fleet-wide gap — `golden.test.ts` checks across all ~107 law MCPs use the bare `existsSync` check. Belgian's fix is the porting reference.

## Local verification

- `npx tsc --noEmit` — clean (no TypeScript errors)
- `npx vitest run` — 10/10 unit-test files pass; contract test file skips cleanly with no DB present
- 47 tests pass, 72 contract assertions correctly skipped (the ones that need real DB content)

## Test plan

- [ ] CI green on this PR (with empty-DB skip in effect)
- [ ] After merge, rebase #97 onto `main` → unblocks the cleanup PR
- [ ] After merge, the dependabot PRs (#94/#98/#99) currently red on the same root cause should rebase clean

## Related

Unblocks #97 (golden-standard cleanup) and the dependabot queue blocked on the same root cause.