### PR TITLE
fix(parser): match JSDOM-serialised article anchors (was 88% over-split)

### DIFF
--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -1,0 +1,304 @@
+#!/usr/bin/env tsx
+/**
+ * Belgian Law ingestion pipeline.
+ *
+ * Three-phase pipeline:
+ *   Phase 1 (Discovery): Fetch year indices, extract law metadata
+ *   Phase 2 (Content FR): Fetch and parse French law texts
+ *   Phase 3 (Content NL): Fetch and parse Dutch law texts
+ *
+ * Usage:
+ *   npm run ingest
+ *   npm run ingest -- --limit 5 --year-start 2023 --year-end 2024
+ *   npm run ingest -- --lang fr --limit 10
+ *   npm run ingest -- --phase discovery
+ *   npm run ingest -- --phase content --lang both
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { fetchYearIndex, fetchLawContent, buildJustelUrl } from './lib/fetcher.js';
+import { parseYearIndex, parseLawContent } from './lib/parser.js';
+import type { LawIndexEntry } from './lib/parser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DATA_DIR = path.resolve(__dirname, '../data');
+const SOURCE_DIR = path.resolve(DATA_DIR, 'source');
+const SEED_DIR = path.resolve(DATA_DIR, 'seed');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI argument parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface CliOptions {
+  yearStart: number;
+  yearEnd: number;
+  limit: number;
+  lang: 'fr' | 'nl' | 'both';
+  phase: 'all' | 'discovery' | 'content';
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const options: CliOptions = {
+    yearStart: 1994,
+    yearEnd: new Date().getFullYear(),
+    limit: 0,
+    lang: 'both',
+    phase: 'all',
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--year-start':
+        options.yearStart = parseInt(args[++i], 10);
+        break;
+      case '--year-end':
+        options.yearEnd = parseInt(args[++i], 10);
+        break;
+      case '--limit':
+        options.limit = parseInt(args[++i], 10);
+        break;
+      case '--lang':
+        options.lang = args[++i] as 'fr' | 'nl' | 'both';
+        break;
+      case '--phase':
+        options.phase = args[++i] as 'all' | 'discovery' | 'content';
+        break;
+    }
+  }
+
+  return options;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Seed JSON types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SeedProvision {
+  provision_ref: string;
+  section: string;
+  title: string;
+  content: string;
+  chapter?: string;
+}
+
+interface SeedDocument {
+  id: string;
+  type: 'statute';
+  title: string;
+  status: 'in_force';
+  issued_date: string;
+  url: string;
+  language: string;
+  numac: string;
+  provisions: SeedProvision[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 1: Discovery
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runDiscovery(options: CliOptions): Promise<LawIndexEntry[]> {
+  console.log('\n=== Phase 1: Discovery ===\n');
+  console.log(`Fetching French law indices for years ${options.yearStart}-${options.yearEnd}...\n`);
+
+  fs.mkdirSync(SOURCE_DIR, { recursive: true });
+
+  const allEntries: LawIndexEntry[] = [];
+
+  for (let year = options.yearStart; year <= options.yearEnd; year++) {
+    try {
+      const html = await fetchYearIndex(year, 'fr');
+      const entries = parseYearIndex(html, 'fr');
+      console.log(`  ${year}: ${entries.length} laws found`);
+      allEntries.push(...entries);
+    } catch (error) {
+      console.error(`  ${year}: FAILED - ${(error as Error).message}`);
+    }
+  }
+
+  // Apply limit if set
+  const limited = options.limit > 0 ? allEntries.slice(0, options.limit) : allEntries;
+
+  // Save index
+  const indexPath = path.join(SOURCE_DIR, 'law-index.json');
+  fs.writeFileSync(indexPath, JSON.stringify(limited, null, 2));
+  console.log(`\nSaved ${limited.length} entries to ${indexPath}`);
+
+  return limited;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 2: French content
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runFrenchContent(entries: LawIndexEntry[], options: CliOptions): Promise<void> {
+  console.log('\n=== Phase 2: French Content ===\n');
+  console.log(`Processing ${entries.length} laws...\n`);
+
+  fs.mkdirSync(SEED_DIR, { recursive: true });
+
+  let processed = 0;
+  let failed = 0;
+
+  for (const entry of entries) {
+    try {
+      const html = await fetchLawContent(entry.year, entry.month, entry.day, entry.numac, 'fr');
+      const parsed = parseLawContent(html, entry.numac);
+
+      if (parsed.provisions.length === 0) {
+        console.log(`  Skipping ${entry.numac} (no articles found): ${entry.title.substring(0, 60)}...`);
+        continue;
+      }
+
+      // Build seed document
+      const seedId = `loi-${entry.date}-${entry.numac}-fr`;
+      const seed: SeedDocument = {
+        id: seedId,
+        type: 'statute',
+        title: parsed.title || entry.title,
+        status: 'in_force',
+        issued_date: entry.date,
+        url: buildJustelUrl(entry.year, entry.month, entry.day, entry.numac, 'fr'),
+        language: 'fr',
+        numac: entry.numac,
+        provisions: parsed.provisions.map(p => ({
+          provision_ref: p.provision_ref,
+          section: p.section,
+          title: p.title,
+          content: p.content,
+          ...(p.chapter ? { chapter: p.chapter } : {}),
+        })),
+      };
+
+      const seedPath = path.join(SEED_DIR, `${seedId}.json`);
+      fs.writeFileSync(seedPath, JSON.stringify(seed, null, 2));
+      processed++;
+      console.log(`  [${processed}/${entries.length}] ${entry.numac}: ${parsed.provisions.length} articles - ${entry.title.substring(0, 50)}...`);
+    } catch (error) {
+      failed++;
+      console.error(`  FAILED ${entry.numac}: ${(error as Error).message}`);
+    }
+  }
+
+  console.log(`\nFrench: ${processed} processed, ${failed} failed`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 3: Dutch content
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function runDutchContent(entries: LawIndexEntry[], _options: CliOptions): Promise<void> {
+  console.log('\n=== Phase 3: Dutch Content ===\n');
+  console.log(`Attempting Dutch versions for ${entries.length} laws...\n`);
+
+  fs.mkdirSync(SEED_DIR, { recursive: true });
+
+  let processed = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const entry of entries) {
+    try {
+      const html = await fetchLawContent(entry.year, entry.month, entry.day, entry.numac, 'nl');
+      const parsed = parseLawContent(html, entry.numac);
+
+      if (parsed.provisions.length === 0) {
+        skipped++;
+        continue;
+      }
+
+      // Check if Dutch title differs from French (confirms it's actually a Dutch version)
+      const seedId = `wet-${entry.date}-${entry.numac}-nl`;
+      const seed: SeedDocument = {
+        id: seedId,
+        type: 'statute',
+        title: parsed.title || entry.title,
+        status: 'in_force',
+        issued_date: entry.date,
+        url: buildJustelUrl(entry.year, entry.month, entry.day, entry.numac, 'nl'),
+        language: 'nl',
+        numac: entry.numac,
+        provisions: parsed.provisions.map(p => ({
+          provision_ref: p.provision_ref,
+          section: p.section,
+          title: p.title,
+          content: p.content,
+          ...(p.chapter ? { chapter: p.chapter } : {}),
+        })),
+      };
+
+      const seedPath = path.join(SEED_DIR, `${seedId}.json`);
+      fs.writeFileSync(seedPath, JSON.stringify(seed, null, 2));
+      processed++;
+      console.log(`  [${processed}] NL ${entry.numac}: ${parsed.provisions.length} articles`);
+    } catch (error) {
+      failed++;
+      // Dutch version may not exist for all laws; this is expected
+      if (String(error).includes('404')) {
+        skipped++;
+      } else {
+        console.warn(`  NL FAILED ${entry.numac}: ${(error as Error).message}`);
+      }
+    }
+  }
+
+  console.log(`\nDutch: ${processed} processed, ${failed} failed, ${skipped} skipped (no Dutch version)`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+
+  console.log('Belgian Law Ingestion Pipeline');
+  console.log('==============================');
+  console.log(`Years: ${options.yearStart}-${options.yearEnd}`);
+  console.log(`Limit: ${options.limit || 'none'}`);
+  console.log(`Language: ${options.lang}`);
+  console.log(`Phase: ${options.phase}`);
+
+  let entries: LawIndexEntry[];
+
+  // Phase 1: Discovery
+  if (options.phase === 'all' || options.phase === 'discovery') {
+    entries = await runDiscovery(options);
+  } else {
+    // Load existing index
+    const indexPath = path.join(SOURCE_DIR, 'law-index.json');
+    if (!fs.existsSync(indexPath)) {
+      console.error('No law-index.json found. Run discovery phase first.');
+      process.exit(1);
+    }
+    entries = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as LawIndexEntry[];
+    if (options.limit > 0) {
+      entries = entries.slice(0, options.limit);
+    }
+    console.log(`\nLoaded ${entries.length} entries from existing index.`);
+  }
+
+  // Phase 2: French content
+  if (options.phase === 'all' || options.phase === 'content') {
+    if (options.lang === 'fr' || options.lang === 'both') {
+      await runFrenchContent(entries, options);
+    }
+
+    // Phase 3: Dutch content
+    if (options.lang === 'nl' || options.lang === 'both') {
+      await runDutchContent(entries, options);
+    }
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/lib/parser.ts
+++ b/scripts/lib/parser.ts
@@ -271,8 +271,14 @@ export function parseLawContent(html: string, numac: string): ParsedLaw {
 function parseArticles(html: string): ParsedProvision[] {
   const provisions: ParsedProvision[] = [];
 
-  // Split on article anchors: <A NAME='Art.XXX'>
-  const articlePattern = /<A\s+NAME='Art\.([^']+)'[^>]*>/gi;
+  // Split on article anchors: <a name="Art.XXX"> (Justel emits single quotes in
+  // the raw page, but this HTML has been round-tripped through JSDOM —
+  // parseLawContent reads textSection.innerHTML — which re-serialises attributes
+  // lower-cased and DOUBLE-quoted (<a name="Art.1">). A single-quote-only regex
+  // therefore matched ZERO anchors on every document, silently forcing the
+  // over-splitting fallback parser (which splits on every inline "Article N"
+  // cross-reference). Match either quote style so the anchor path actually runs.
+  const articlePattern = /<a\s+name=["']Art\.([^"']+)["'][^>]*>/gi;
   const matches: Array<{ ref: string; startIndex: number }> = [];
 
   let match: RegExpExecArray | null;
@@ -350,10 +356,15 @@ function parseArticlesFallback(html: string): ParsedProvision[] {
   const provisions: ParsedProvision[] = [];
   const cleanText = cleanArticleHtml(html);
 
-  const parts = cleanText.split(/(?=(?:Article|Art\.)\s+\d+)/i);
+  // Split only at a LINE START followed by a capitalised "Article N" / "Art. N".
+  // The previous `/(?=(?:Article|Art\.)\s+\d+)/i` split anywhere and was
+  // case-insensitive, so every inline lowercase cross-reference ("à l'article 5")
+  // started a phantom provision and truncated its parent mid-sentence. Real
+  // article headings begin a line and are capitalised; cross-references do not.
+  const parts = cleanText.split(/(?:^|\n)(?=(?:Article|Art\.)\s+\d)/);
 
   for (const part of parts) {
-    const artMatch = part.match(/^(?:Article|Art\.)\s+(\d+(?:er)?)/i);
+    const artMatch = part.match(/^(?:Article|Art\.)\s+(\d+(?:er)?)/);
     if (!artMatch) continue;
 
     const num = artMatch[1];

--- a/tests/fixtures/justel-1994009284.html
+++ b/tests/fixtures/justel-1994009284.html
@@ -1,0 +1,269 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="iso-8859-1" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/img_2024/logos/justitie_favicon.svg"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Banque de donn&eacute;es Justel</title>
+    <script type="module" crossorigin src="/css_2024/article.js"></script>
+    <script type="module" crossorigin src="/css_2024/index.js"></script>
+    <link rel="stylesheet" crossorigin href="/css_2024/index.css">
+    <link rel="stylesheet" crossorigin href="/css_2024/article.css">
+   </head>
+  <body>
+    <div class="page">
+      <!-- Dit is sectie voor top navigatie, taal en andere diensten -->
+      <div class="page__wrapper page__wrapper--tools no-print">
+        <div class="page__section page__section--tools">
+          <nav>
+            <ul>
+              <li class="nav-language-item">
+                <a href="/cgi_loi/article.pl?language=nl&lg_txt=n&type=&sort=&numac_search=&cn_search=1994020233&caller=eli&&view_numac=1994020233fr" class="nav__language-button ">NL</a>
+              </li>
+              <li class="nav-language-item">
+                <a href="/cgi_loi/article.pl?language=fr&lg_txt=f&type=&sort=&numac_search=&cn_search=1994020233&caller=eli&&view_numac=1994020233fr" class="nav__language-button active">FR</a>
+              </li>
+              <li class="nav-language-item">
+                <a href="/cgi_loi/article.pl?language=de&lg_txt=d&type=&sort=&numac_search=&cn_search=1994020233&caller=eli&&view_numac=1994020233fr" class="nav__language-button ">DE</a>
+              </li>
+            </ul>
+          </nav>
+          <div>
+            <small class="nav__federalheader__link"
+              >Autres informations et services officiels:
+              <a href="https://www.belgium.be/fr">www.belgium.be</a> 
+              </small>
+              <a href="https://www.belgium.be/fr">
+              <img src="/img_2024/logos/logo-be_black.svg"
+              alt="Logo of the Belgian Federal Authorities"
+              class="nav__federalheader__logo"
+            />
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <!-- Dit is sectie voor logo en menu -->
+      <div class="page__wrapper page__wrapper--header no-print">
+        <header class="page__section page__section--header">
+          <div class="justice-logo">
+            <a href="https://justice.belgium.be/fr" title="Return to the Service public Fédéral Justice homepage" rel="home">
+              <img
+                src="/img_2024/logos/fod-fr.svg"
+                class="site-name"
+                alt="Return to the Service public Fédéral Justice homepage"
+                width="168"
+                height="36"
+              />
+            </a>
+          </div>
+          <button
+            id="headerCollapsibleButton"
+            type="button"
+            class="button button--toggler close"
+            aria-controls="headerCollapsible"
+            aria-expanded="false"
+            style="cursor: pointer"
+          >
+            <span class="label">Menu</span>
+            <span class="menu-icon"></span>
+          </button>
+          <div class="region region--header-collapsible" id="headerCollapsible">
+            <nav
+              id="block-header"
+              aria-label="Header"
+              class="block block--menu block--menu--header block--region-header-collapsible"
+            >
+              <div class="block__content">
+                <ul class="menu menu-level-0">
+                  <li class="menu-item">
+                    <a href="/cgi/welcome.pl?language=fr">Moniteur belge</a>
+                  </li>
+
+                  <li class="menu-item menu-item--collapsed">
+                    <a href="/cgi_tsv_pub/welcome.pl?language=fr">Annexe Personnes<br> morales</a>
+                  </li>
+                  <li class="menu-item menu-item--collapsed">
+                    <a href="/cgi_loi/welcome.pl?language=fr&view_numac=1994020233fr">Banque de <br>donn&eacute;es Justel</a>
+                  </li>
+                 <li class="menu-item menu-item--collapsed">
+                    <a href="/cgi/faq.pl?language=fr">FAQ</a>
+                  </li>
+                </ul>
+              </div>
+            </nav>
+          </div>
+        </header>
+      </div>
+
+<!-- Dit is sectie voor breadcrumbs -->
+       <div class="page__wrapper page__wrapper--breadcrumb no-print">
+         <div class="page__section page__section--breadcrumb">
+           <div
+             id="block-justice-theme-breadcrumbs"
+             class="block block--system block--system--justice-theme-breadcrumbs block--system--breadcrumb"
+           >
+             <div class="block__content">
+               <nav class="breadcrumb" aria-label="Kruimelpad">
+                 <ol>
+                   <li><a href="https://www.ejustice.just.fgov.be/cgi/welcome.pl?language=fr" title="Home" class="item">Home</a></li>
+                   <li>
+                     <span class="item"><a href="/cgi_loi/welcome.pl?language=fr&view_numac=1994020233fr" title="Accueil">Banque de donn&eacute;es Justel</a></span>
+                   </li>
+                   <li>
+                     <span class="item">Dossier numéro : 1994020233</span>
+                   </li>
+                 </ol>
+               </nav>
+             </div>
+           </div>
+         </div>
+       </div>
+  <script type="module" crossorigin src="/css_2024/justelDetail.js"></script>
+ <link rel="stylesheet" crossorigin href="/css_2024/justelDetail.css">
+<!-- Dit is sectie voor titel  -->
+      <div class="page__wrapper page__wrapper--top">
+        <div class="page__section page__section--top with-editions">
+         
+        </div>
+      </div>
+    </div>
+
+    <!-- Dit is sectie voor content -->
+    <div class="page__wrapper page__wrapper--content">
+      <div class="page__section page__section--content">
+        <main class="page__inner page__inner--content" role="main">
+          <div class="list-content">
+            <div popover id="sidenav-popover" class="mobile-side-bar no-print">
+              <div class="toc-mobile"></div>
+              <button class="back-to-top-button no-print">Haut de la page</button>
+            </div>
+            <button
+              popovertarget="sidenav-popover"
+              class="side-bar-mobile-button no-print"
+            ></button>
+
+            <div class="list-side-bar">
+              <div class="toc-desktop"></div>
+              <button class="back-to-top-button side-bar--item">
+                Haut de la page
+              </button>
+            </div>
+            <div class="list">
+              <div id="list-title-1" class="box">
+                <h2 class="list-title" id="list-link-1">Titre</h2>
+                <div class="list-item">
+                  <div class="list-item--content">
+                    <span class="tag">1994009284</span>
+                    <p class="list-item--subtitle">
+                      
+                    </p>
+                    <p class="list-item--title">
+                      2 FEVRIER 1994. - Loi modifiant la loi du 8 avril 1965 relative à la protection de la jeunesse.
+                    </p>
+                    <div class="plain-text">
+<p><strong>Source: </strong>Justice</p>                     
+                      <p><strong>Publication: </strong>17 septembre 1994</p>
+                      <p><strong>Num&eacute;ro: </strong>1994009284</p>
+                      <p><strong>page: </strong>23629 </p>
+                      <p><strong>Dossier num&eacute;ro:</strong>  1994-02-02/33</p>
+<p><strong>Entr&eacute;e en vigueur :</strong> 27 septembre 1994 </p>
+
+
+
+<p><strong>Ce texte modifie les textes suivants:</strong></p>   <span class="tag-small"><a href="/cgi_loi/article.pl?language=fr&numac_search=1990009905" target="_blank">1990009905</a></span>  <span class="tag-small"><a href="/cgi_loi/article.pl?language=fr&numac_search=1965040806" target="_blank">1965040806</a></span>
+
+<p><strong><a href="/cgi_loi/article.pl?language=fr&arrexec=1&lg_txt=f&type=&sort=&numac_search=1994009284&cn_search=1994020233&caller=eli&&view_numac=1994020233fr">3  arrêt&eacute;s d'ex&eacute;cution</a></strong></p>
+             </div>
+                </div>
+              </div>
+</div>
+              
+              <div id="list-title-2" class="box plain-text">
+                <h2 id="inhoud" class="list-title" id="list-link-2">Table des matières</h2> 
+                  Art. 1-33<BR><A NAME='LNKR0001' HREF='#LNK0001'>Dispositions diverses.</A><BR>Art. 34-37
+              </div>
+              <div id="list-title-3" class="box plain-text">
+                <h2 id="text" class="list-title" id="list-link-3">Texte</h2> 
+                  <A NAME='Art.1'></A>Article <A HREF='#Art.2'>1</A>. A l'article 36bis de la loi du 8 avril 1965 relative à la protection de la jeunesse, y inséré par la loi du 9 mai 1972 et modifié par la loi du 19 janvier 1990, sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;a) à l'alinéa 1er, les mots &quot; mineurs de plus de seize ans &quot; sont remplacés par les mots &quot; personnes de plus de seize ans et de moins de dix-huit ans &quot;;<BR>&nbsp;&nbsp;b) au 3° du même alinéa 1er, les mots &quot; à la loi du 1er juillet 1956 &quot; sont remplacés par les mots &quot; à la loi du 21 novembre 1989 &quot;;<BR>&nbsp;&nbsp;c) à l'alinéa 2, la première phrase est supprimée;<BR>&nbsp;&nbsp;d) dans la deuxième phrase du même alinéa 2, les mots &quot; s'ils &quot; sont remplacés par les mots &quot; si les débats devant ces juridictions &quot;;<BR>&nbsp;&nbsp;e) au troisième alinéa, les mots &quot; mineurs visés &quot; sont remplacés par les mots &quot; personnes visées &quot;.<BR><BR>&nbsp;&nbsp;<A NAME='Art.2' HREF='#Art.1'>Art.</A> <A HREF='#Art.3'> 2</A>. L'article 37 de la même loi, modifié par le décret de la Communauté flamande du 27 juin 1985, partiellement abrogé par le décret de la Communauté flamande du 28 mars 1990, modifié par le décret de la Communauté française du 4 mars 1991 et par le décret de la Communauté germanophone du 18 février 1991 et remplacé par la loi du 24 décembre 1992, est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Article 37. § 1. Le tribunal de la jeunesse peut ordonner à l'égard des personnes qui lui sont déférées, des mesures de garde, de préservation et d'éducation.<BR>&nbsp;&nbsp;§ 2. Il peut selon les circonstances :<BR>&nbsp;&nbsp;1° les réprimander et, sauf en ce qui concerne celles qui ont atteint dix-huit ans, les laisser ou les rendre aux personnes qui en ont la garde en leur enjoignant le cas échéant de mieux les surveiller à l'avenir;<BR>&nbsp;&nbsp;2° les soumettre à la surveillance du service social compétent chargé de veiller à l'observation des conditions fixées par le tribunal.<BR>&nbsp;&nbsp;Le tribunal peut subordonner le maintien des personnes visées au § 1er dans leur milieu, notamment à une ou plusieurs des conditions suivantes :<BR>&nbsp;&nbsp;a) fréquenter régulièrement un établissement scolaire d'enseignement ordinaire ou spécial;<BR>&nbsp;&nbsp;b) accomplir une prestation éducative ou philantropique en rapport avec leur âge et leurs ressources;<BR>&nbsp;&nbsp;c) se soumettre aux directives pédagogiques et médicales d'un centre d'orientation éducative ou d'hygiène mentale;<BR>&nbsp;&nbsp;3° les placer sous surveillance du service social compétent, chez une personne digne de confiance ou dans un établissement approprié, en vue de leur hébergement, de leur traitement, de leur éducation, de leur instruction ou de leur formation professionnelle;<BR>&nbsp;&nbsp;4° les confier à une institution publique d'observation et d'éducation sous surveillance ou au groupe des institutions publiques d'observation et d'éducation sous surveillance. En ce qui concerne les personnes visées à l'article 36, 4° et sans préjudice des dispositions de l'article 60, la décision précise la durée de la mesure et si elle prescrit un régime éducatif fermé organisé par les autorités compétentes en vertu de l'article 59bis, §§ 2bis et 4bis de la Constitution et de l'article 5, § 1er, II, 6°, de la loi spéciale du 8 août 1980 de réformes institutionnelles, modifiée par la loi du 8 août 1988.<BR>&nbsp;&nbsp;L'accès aux institutions publiques d'observation et d'éducation sous surveillance est réservé, sauf circonstances très exceptionnelles, au jeune âgé de plus de douze ans.<BR>&nbsp;&nbsp;§ 3. Les mesures prévues au § 2, 2° à 4°, sont suspendues lorsque l'intéressé se trouve sous les armes. Elles prennent fin lorsque l'intéressé atteint dix-huit ans.<BR>&nbsp;&nbsp;Toutefois, à l'égard des personnes visées à l'article 36, 4°, et sans préjudice de l'article 60 :<BR>&nbsp;&nbsp;1° à la requête de l'intéressé, ou sur réquisition du ministère public en cas de mauvaise conduite persistante ou de comportement dangereux de l'intéressé, une prolongation de ces mesures peut être ordonnée, par jugement, pour une durée déterminée ne dépassant pas le jour où l'intéressé atteindra l'âge de vingt ans. Le tribunal est saisi de la requête ou de la réquisition dans les trois mois précédant le jour de la majorité de l'intéressé;<BR>&nbsp;&nbsp;2° ces mesures pourront être ordonnées par jugement pour une durée déterminée ne dépassant pas le jour où l'intéressé atteindra vingt ans, lorsqu'il s'agit de personnes qui ont commis un fait qualifié infraction après l'âge de dix-sept ans.<BR>&nbsp;&nbsp;En cas d'appel contre ces jugements, la chambre de la jeunesse de la cour d'appel statue d'urgence. L'appel n'est pas suspensif. Les jugements et arrêts prononcés en application de cet article ne sont pas susceptibles d'opposition.<BR>&nbsp;&nbsp;§ 4. La mesure de réprimande prévue au § 2, 1°, est applicable aux personnes qui ont commis un fait qualifié infraction avant l'âge de dix-hui ans, même si elles ont dépassé cet âge au moment du jugement.<BR>&nbsp;&nbsp;Les personnes visées à l'alinéa précédent qui ont atteint l'âge de dix-huit ans au moment du jugement, sont assimilées aux mineurs pour l'application des dispositions du chapitre IV du présent titre, ainsi que de l'article 80 de la pésente loi. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.3' HREF='#Art.2'>Art.</A> <A HREF='#Art.4'> 3</A>. L'article 38 de la même loi est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Article 38. Si la personne déférée au tribunal de la jeunesse en raison d'un fait qualifié infraction était âgée de plus de seize ans au moment de ce fait et que le tribunal de la jeunesse estime inadéquate une mesure de garde, de préservation ou d'éducation, il peut par décision motivée se dessaisir et renvoyer l'affaire au ministère public aux fins de poursuite devant la juridiction compétente en vertu du droit commun s'il y a lieu.<BR>&nbsp;&nbsp;La disposition qui précède peut être appliquée même lorsque l'intéressé a atteint l'âge de dix-huit ans au moment du jugement. Il est dans ce cas assimilé à un mineur pour l'application des dispositions du chapitre IV du présent titre, ainsi que de l'article 80 de la présente loi.<BR>&nbsp;&nbsp;Toute personne qui a fait l'objet d'une décision de dessaisissement prononcée en application du présent article, devient justiciable de la juridiction ordinaire pour les poursuites relatives aux faits commis à partir du lendemain du jour de sa condamnation définitive par la juridiction compétente. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.4' HREF='#Art.3'>Art.</A> <A HREF='#Art.5'> 4</A>. L'article 39 de la même loi partiellement abrogé et modifié par le décret de la Communauté flamande du 28 mars 1990, est complété par l'alinéa suivant :<BR>&nbsp;&nbsp;&quot; La présente disposition n'est pas applicable aux personnes qui ont commis un fait qualifié infraction. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.5' HREF='#Art.4'>Art.</A> <A HREF='#Art.6'> 5</A>. L'article 41 de la même loi, partiellement abrogé et modifié par le décret de la Communauté flamande du 28 mars 1990 et modifié par le décret de la Communauté française du 14 mai 1990 et par le décret de la Communauté germanophone du 18 février 1991, est complété par l'alinéa suivant :<BR>&nbsp;&nbsp;&quot; La présente disposition n'est pas applicable aux personnes qui ont commis un fait qualifié infraction. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.6' HREF='#Art.5'>Art.</A> <A HREF='#Art.7'> 6</A>. A l'article 42, alinéa 2, de la même loi, modifié par le décret de la Communauté flamande du 27 juin 1985, abrogé par le décret de la Communauté flamande du 28 mars 1990 et modifié par le décret de la Communauté française du 4 mars 1991, les mots &quot; le Comité de protection de la jeunesse ou un délégué à la protection de la jeunesse &quot; sont remplacés par les mots &quot; le service social compétent &quot;.<BR><BR>&nbsp;&nbsp;<A NAME='Art.7' HREF='#Art.6'>Art.</A> <A HREF='#Art.8'> 7</A>. L'article 44 de la même loi, modifié par la loi du 21 mars 1969, est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Article 44. Sans préjudice des articles 350, 353 et 367, § 2 du Code civil, la compétence territoriale du tribunal de la jeunesse est déterminée par la résidence des parents, tuteurs ou personnes qui ont la garde de la personne de moins de dix-huit ans.<BR>&nbsp;&nbsp;Lorsque ceux-ci n'ont pas de résidence en Belgique ou lorsque leur résidence est inconnue ou incertaine, le tribunal de la jeunesse compétent est celui du lieu où l'intéressé à commis le fait qualifié infraction, du lieu où il est trouvé ou du lieu où la personne ou l'établissement auquel il a été confié par les instances compétentes a sa résidence ou son siège.<BR>&nbsp;&nbsp;Lorsque le tribunal de la jeunesse est saisi après que l'intéressé a atteint l'âge de dix-huit ans, le tribunal de la jeunesse compétent est celui du lieu de la résidence de l'intéressé, ou, si celle-ci est inconnue ou incertaine, le lieu où le fait qualifié infraction a été commis.<BR>&nbsp;&nbsp;Néanmoins le tribunal de la jeunesse compétent est :<BR>&nbsp;&nbsp;1° celui de la résidence du requérant en cas d'application des articles 477 du Code civil et 63, alinéa 5, de la présente loi;<BR>&nbsp;&nbsp;2° celui dans le ressort duquel le conseil de famille s'est réuni en vertu des articles 361, § 3, 367, § 7, 478 et 479 du Code civil.<BR>&nbsp;&nbsp;Si les parents, tuteurs ou personnes qui ont la garde d'une personne âgée de moins de dix-huit ans ayant fait l'objet d'une mesure de garde, de préservation ou d'éducation changent de résidence, ils doivent sous peine d'amende d'un à vingt-cinq francs, en donner avis sans délai au tribunal de la jeunesse à la protection duquel cette personne est confiée.<BR>&nbsp;&nbsp;Le changement de résidence entraîne le dessaisissement de ce tribunal au profit du tribunal de la jeunesse de l'arrondissement où est située la nouvelle résidence. Le dossier lui est transmis par le greffier du tribunal dessaisi.<BR>&nbsp;&nbsp;Le tribunal saisi reste cependant compétent pour statuer en cas de changement de résidence survenant au cours d'instance. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.8' HREF='#Art.7'>Art.</A> <A HREF='#Art.9'> 8</A>. Dans l'article 45 de la même loi, modifié par la loi du 21 mars 1969 sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° au 1, les mots &quot; sans préjudice des articles 350, 353, &quot; sont remplacés par les mots &quot; sans préjudice des articles 145, 350, 353, &quot;;<BR>&nbsp;&nbsp;2° au 1, les mots &quot; selon le cas, par les père, &quot; sont remplacés par les mots &quot; selon le cas, par le mineur, les père, &quot;;<BR>&nbsp;&nbsp;3° au 1, les mots &quot; de la commission d'assistance publique &quot; sont remplacés par les mots &quot; du centre public d'aide sociale &quot;;<BR>&nbsp;&nbsp;4° au 2, b), les mots &quot; ou en vue du dessaisissement prévu à l'article 38 &quot; sont insérés entre les mots &quot; au fond &quot; et &quot; les parties &quot;;<BR>&nbsp;&nbsp;5° le 2 est complété comme suit :<BR>&nbsp;&nbsp;&quot; c) par la requête visée aux articles 37, § 3, 1° et 60, les parties étant convoquées, dans ce cas, par pli judiciaire adressé suivant les formes prévues à l'article 46, § 1er, du Code judiciaire. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.9' HREF='#Art.8'>Art.</A> <A HREF='#Art.10'> 9</A>. L'article 46 de la même loi est complété comme suit :<BR>&nbsp;&nbsp;&quot; Si une personne visée à l'article 36, 4°, a atteint l'âge de dix-huit ans au moment où l'action est intentée, la citation ou l'avertissement visé à l'alinéa précédent est adressé à cette personne qui a fait l'objet de la mesure et aux personnes qui en étaient civilement responsables du fait de sa minorité.<BR>&nbsp;&nbsp;Sans préjudice de l'article 184, alinéa 3, du Code d'instruction criminelle, il y aura au moins un délai de dix jours, sans augmentation en raison de la distance, entre la citation et la comparution, à peine de nullité du jugement qui sera prononcé par défaut par le tribunal à l'égard de la partie citée. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.10' HREF='#Art.9'>Art.</A> <A HREF='#Art.11'> 10</A>. L'article 48 de la même loi est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Article 48. § 1. Dans les procédures visées au titre II, chapitre II, section 1er, chaque parent ou personne ayant la garde d'un jeune fait l'objet d'une procédure distincte.<BR>&nbsp;&nbsp;Ces procédures ne peuvent être jointes à d'autres procédures que pendant la procédure préparatoire. Les pièces contenant des informations relatives à chacun des parents ou personnes ayant la garde de l'intéressé doivent être séparées des autres pièces de la procédure. Elles ne peuvent être communiquées aux autres parties.<BR>&nbsp;&nbsp;Pendant la durée de la procédure préparatoire, le ministère public peut refuser la communication de ces pièces aux parties, s'il juge que cette communication serait de nature à nuire aux intérêts des personnes concernées.<BR>&nbsp;&nbsp;§ 2. Dans les procédures visées au titre II, chapitre III, section 2, lorsque le fait qu'aurait commis la personne de moins de dix-huit ans et connexe à une infraction qu'auraient commise une ou plusieurs personnes non justiciables du tribunal de la jeunesse, les poursuites sont disjointes dès que la disjonction peut avoir lieu sans nuire à l'information ou à l'instruction.<BR>&nbsp;&nbsp;Les poursuites peuvent être jointes si le tribunal de la jeunesse s'est dessaisi conformément à l'article 38. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.11' HREF='#Art.10'>Art.</A> <A HREF='#Art.12'> 11</A>. Dans l'article 49 de la même loi sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° l'alinéa 2 est remplacé par ce qui suit :<BR>&nbsp;&nbsp;&quot; S'il y a urgence, le juge d'instruction peut prendre à l'égard de la personne de moins de dix-huit ans une des mesures de garde visées aux articles 52 et 53, sans préjudice à en donner avis simultanément et par écrit au tribunal de la jeunesse, qui exerce dès lors ses attributions et statute dans les deux jours ouvrables, conformément aux articles 52ter et 52quater. &quot;;<BR>&nbsp;&nbsp;2° l'alinéa 3 est complété comme suit :<BR>&nbsp;&nbsp;&quot; Cette ordonnance est prononcée après un débaut contradictoire et après que la personne de moins de dix-huit ans, les père et mère et les parties civiles aient pu prendre connaissance du dossier relatif aux faits, déposé au greffe 48 heures au moins avant les débats. &quot;;<BR>&nbsp;&nbsp;3° l'article est complété par l'alinéa suivant :<BR>&nbsp;&nbsp;&quot; L'alinéa 3 ne fait pas obstacle à ce que le ministère public saisisse le tribunal de la jeunesse d'une réquisition tenant au dessaisissement prévu à l'article 38. Le tribunal statue en l'état de la procédure. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.12' HREF='#Art.11'>Art.</A> <A HREF='#Art.13'> 12</A>. L'article 50 de la même loi, modifié par le décret de la Communauté française du 4 mars 1991, est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Article 50. § 1. Le tribunal de la jeunesse effectue toutes diligences et fait procéder à toutes investigations utiles pour connaître la personnalité de l'intéressé, le milieu où il est élevé, déterminer son intérêt et les moyens appropriés à son éducation ou à son traitement.<BR>&nbsp;&nbsp;Il peut faire procéder à une étude sociale par l'intermédiaire du service social compétent et soumettre l'intéressé à un examen médico-psychologique, lorsque le dossier qui lui est soumis, ne lui paraît pas suffisant.<BR>&nbsp;&nbsp;Lorsque le tribunal de la jeunesse fait procéder à une étude sociale, il ne eput, sauf en cas d'extrême urgence, prendre ou modifier sa décision, qu'après avoir pris connaissance de l'avis du service social compétent, à moins que cet avis ne lui parvienne pas dans le délai qu'il a fixé et qui ne peut dépasser septante-cinq jours.<BR>&nbsp;&nbsp;Sans préjudice de l'article 36bis, le tribunal de la jeunesse ne peut se dessaisir d'une affaire, dans les conditions prévues par l'article 38, qu'après avoir fait procéder à l'étude sociale et à l'examen médico-psychologique prévus à l'alinéa deux.<BR>&nbsp;&nbsp;§ 2. Toutefois,<BR>&nbsp;&nbsp;1° le tribunal de la jeunesse peut se dessaisir d'une affaire sans disposer du rapport de l'examen médico-psychologique lorsqu'il constate que l'intéressé se soustrait à cet examen ou refuse de s'y soumettre;<BR>&nbsp;&nbsp;2° le tribunal de la jeunesse statue sur la demande de dessaisissement dans les quinze jours de la citation, sans devoir faire procéder à une étude sociale et sans devoir demander un examen médico-psychologique, lorsqu'une mesure a déjà été prise par jugement à l'égard d'une personne de moins de dix-huit ans en raison d'un ou plusieurs faits visés aux articles 323, 373 à 378, 392 à 394, 401 et 468 à 476 du Code pénal, commis après l'âge de seize ans, et que cette personne est à nouveau poursuivie pour un ou plusieurs de ces faits commis postérieurement à la première condamnation. Les pièces de la procédure antérieure sont jointes à la nouvelle procédure;<BR>&nbsp;&nbsp;3° le tribunal de la jeunesse statue dans les mêmes conditions sur la demande de dessaisissement à l'égard d'une personne de moins de dix-huit ans qui a commis un fait qualifié crime punissable d'une peine supérieure aux travaux forcés de vingt ans, commis après l'âge de seize ans et qui n'est poursuivi qu'après qu'il ait atteint l'âge de dix-huit ans. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.13' HREF='#Art.12'>Art.</A> <A HREF='#Art.14'> 13</A>. A l'article 51 de la même loi, modifié par la loi du 21 mars 1969, sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° l'alinéa premier est remplacé par ce qui suit :<BR>&nbsp;&nbsp;&quot; Le tribunal de la jeunesse, une fois saisi, peut en tout temps convoquer l'intéressé, les parents, tuteurs, personnes qui en ont la garde, ainsi que toute autre personne, sans préjudice de l'article 458 du Code pénal, de l'article 156 du Code d'instruction criminelle et de l'article 931 du Code judiciaire. &quot;;<BR>&nbsp;&nbsp;2° dans l'alinéa 2, &quot; 145, &quot; est inséré entre les mots &quot; aux articles &quot; et &quot; 148, &quot;;<BR>&nbsp;&nbsp;3° au même alinéa 2, les mots &quot; 389, alinéa premier &quot; sont remplacés par : &quot; 375, 376, 377, 379 &quot;;<BR>&nbsp;&nbsp;4° au même alinéa 2, les mots &quot; 4 et 5 du Code de commerce &quot; sont supprimés;<BR>&nbsp;&nbsp;5° au même alinéa 2, les mots &quot; 34 et 36 de la loi du 10 mars 1900 sur le contrat de travail &quot; sont remplacés par les mots &quot; 43, 45, 46 et 46bis de la loi du 3 juillet 1978 sur les contrats de travail, modifiée par la loi du 30 mars 1981 &quot;.<BR><BR>&nbsp;&nbsp;<A NAME='Art.14' HREF='#Art.13'>Art.</A> <A HREF='#Art.15'> 14</A>. A l'article 52 de la même loi, partiellement abrogé par le décret de la Communauté flamande du 28 mars 1990 et par le décret de la Communauté française du 4 mars 1991, sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° au deuxième alinéa, les chiffres &quot; 37, 2° &quot; sont remplacés par les chiffres &quot; 37, § 2, 2° &quot;, et les chiffres &quot; 37, 3° et 4° &quot; par les chiffres &quot; 37, § 2, 3° et 4° et 37, § 3, 2° &quot;;<BR>&nbsp;&nbsp;2° le même article 52 est complété par les alinéas suivants :<BR>&nbsp;&nbsp;&quot; Lorsque le tribunal de la jeunesse prend provisoirement une des mesures prévues à l'article 37, § 2, 4°, à l'égard d'une personne ayant commis un fait qualifié infraction, il peut, pour les nécessités de l'information ou de l'instruction et pour un délai renouvelable de trente jours au plus, interdire au jeune par décision motivée de communiquer librement avec les personnes nommément désignées, autres que son avocat.<BR>&nbsp;&nbsp;Lorsque le tribunal de la jeunesse est saisi du cas d'une personne ayant commis avant l'âge de dix-huit ans un fait qualifié infraction et qui a dépassé cet âge au cours de la procédure, il peut ordonner ou maintenir des mesures provisoires jusqu'à ce que l'intéressé ait atteint l'âge de vingt ans. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.15' HREF='#Art.14'>Art.</A> <A HREF='#Art.16'> 15</A>. Un article 52bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Article 52bis. Hors les cas visés à l'article 52quater, alinéa 4, la durée de la procédure préparatoire est limitée à six mois à partir de la réquisition prévue à l'article 45.2.a), jusqu'à la communication du dossier au ministère public après clôture des investigations. Le ministère public dispose alors d'un délai de deux mois pour citer l'intéressé à comparaître devant le tribunal de la jeunesse.<BR>&nbsp;&nbsp;Le délai de six mois est suspendu entre l'acte d'appel et l'arrêt. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.16' HREF='#Art.15'>Art.</A> <A HREF='#Art.17'> 16</A>. Un article 52ter, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Article 52ter. Dans les cas prévus à l'article 52, le jeune ayant atteint l'âge de douze ans doit être entendu personnellement par le juge de la jeunesse avant toute mesurs, sauf s'il n'a pu être trouvé, si son état de santé s'y oppose ou s'il refuse de comparaître.<BR>&nbsp;&nbsp;L'intéressé a droit à l'assistance d'un avocat, lors de toute comparution devant le tribunal de la jeunesse. Cet avocat est désigné, le cas échéant, conformément à l'article 54bis. Hors les cas où le tribunal de la jeunesse est saisi conformément à l'article 45.2.b) ou c), le juge de la jeunesse peut néanmoins avoir un entretien particulier avec l'intéressé.<BR>&nbsp;&nbsp;L'ordonnance contient un résumé des éléments touchant à sa personnalité ou à son milieu, qui justifient la décision et, le cas échéant, un résumé des faits reprochés. Elle mentionne également l'audition ou les raisons pour lesquelles l'intéressé n'a pu être entendu.<BR>&nbsp;&nbsp;Une copie de l'ordonnance est remise à l'intéressé après son audition, de même qu'à ses père et mère, tuteurs ou personnes qui ont la garde de l'intéressé si ceux-ci sont présents à l'audience. Au cas où cette remise n'a pu avoir lieu, la décision est notifiée par pli judiciaire. Le délai d'appel court à partir de la remise de la copie ou à partir du jour où l'intéressé a eu connaissance de la notification par pli judiciaire.<BR>&nbsp;&nbsp;Les mesures visées à l'article 52 ne sont pas susceptibles d'opposition.<BR>&nbsp;&nbsp;En cas d'appel, la chambre de la jeunesse de la courd d'appel statue dans les deux mois au plus tard à compter de l'acte d'appel. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.17' HREF='#Art.16'>Art.</A> <A HREF='#Art.18'> 17</A>. Un article 52quater, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Article 52quater. En ce qui concerne les personnes visées à l'article 36, 4°, le juge ou le tribunal de la jeunsse, selon le cas, peut, dans les cas visés aux articles 52, 52bis et 52ter, ordonner une mesure de garde pour une période de trois mois au plus, en régime éducatif fermé, organisé par les instances compétentes.<BR>&nbsp;&nbsp;Cette décision ne peut être prise qu'en cas de mauvaise conduite persistante ou de comportement dangereux de l'intéressé ou lorsqu'une instruction judiciaire la requiert.<BR>&nbsp;&nbsp;En outre, le juge ou le tribunal de la jeunesse peut, par décision motivée et pour des raisons identiques, interdire aux mêmes personnes et pour le même délai toute sortie de l'établissement.<BR>&nbsp;&nbsp;Ces mesures ne sont renouvelables qu'une seule fois et après communication du rapport médico-psychologique rédigé par l'établissement, l'intéressé et son conseil étant préalablement entendus.<BR>&nbsp;&nbsp;Les mesures précitées peuvent néanmoins être prolongées de mois en mois par décision motivée du juge ou du tribunal de la jeunesse selon le cas. La décision devra être justifiée par des circonstances graves et exceptionnelles se rattachant aux exigences de la sécurité publique ou propres à la personnalité de l'intéressé, et qui nécessitent le maintien de ces mesures. L'intéressé, son conseil et le directeur de l'établissement seront préalablement entendus.<BR>&nbsp;&nbsp;L'appel contre les ordonnances ou jugements prévus aux alinéas précédents doit être interjeté dans un délai de quarante-huit heures qui court à l'égard du ministère public à compter de la communication de l'ordonnance ou du jugement et à l'égard des autres parties en cause à compter de l'accomplissement des formalités prévues à l'article 52ter, alinéa 4. Le recours peut être formé par déclaration au directeur de l'établissement ou à la personne qu'il délègue. Le directeur inscrit les recours dans un registre coté et paraphé. Il en avise immédiatement le greffe du tribunal compétent et lui adresse un extrait du registre par lettre recommandée.<BR>&nbsp;&nbsp;La chambre de la jeunesse de la cour d'appel instruit la cause et se prononce dans les quinze jours ouvrables à compter de l'acte d'appel. Passé ce délai, la mesure cesse d'être d'application. Le délai est suspendu pendant la durée de la remise accordée à la demande de la défense. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.18' HREF='#Art.17'>Art.</A> <A HREF='#Art.19'> 18</A>. Dans l'article 53 de la même loi, partiellement abrogé par le décret de la Communauté flamande du 28 mars 1990 et par le décret de la Communauté française du 4 mars 1991. les alinéas suivants sont insérés entre l'alinéa 1er et l'alinéa 2 :<BR>&nbsp;&nbsp;&quot; La mesure prévue à l'alinéa 1er n'est applicable qu'à l'égard des personnes qui sont soupconnées d'avoir commis un fait punissable d'une peine d'emprisonnement correctionnel principal d'un an ou d'une peine plus grave aux termes du Code pénal ou des lois complémentaires et pour autant qu'elles aient atteint l'âge de quatorze ans au moins au moment des faits.<BR>&nbsp;&nbsp;En cas d'appel, les dispositions de l'article 52quater, alinéas 6 et 7, sont applicables, sauf que le délai dans lequel la décision d'appel doit intervenir est ramené à cinq jours ouvrables à compter de l'acte d'appel.<BR>&nbsp;&nbsp;La mesure de garde visée à l'alinéa premier ne peut être ordonnée qu'une seule fois par le juge de la jeunesse au cours de la même procédure, sauf la possibilité du tribunal de la jeunesse d'ordonner d'autres mesures provisoires.<BR>&nbsp;&nbsp;Cet article est applicable aux personnes visées à l'article 37, § 3, 2°. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.19' HREF='#Art.18'>Art.</A> <A HREF='#Art.20'> 19</A>. Un article 53bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 53bis. L'article 53 de cette loi est abrogé à une date qui sera fixée par arrêté royal délibéré en Conseil des ministres. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.20' HREF='#Art.19'>Art.</A> <A HREF='#Art.21'> 20</A>. L'article 54, premier alinéa, de la même loi, modifié par la loi du 21 mars 1969, est remplacé par ce qui suit :<BR>&nbsp;&nbsp;&quot; Sauf dans les cas prévus au titre II, chapitre III, ou en matière d'adoption ou d'adoption plénière, où elles doivent comparaître en personne, les parties peuvent se faire représenter par un avocat. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.21' HREF='#Art.20'>Art.</A> <A HREF='#Art.22'> 21</A>. Un article 54bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 54bis. § 1. Lorsqu'une personne de moins de dix-huit ans est partie à la cause et qu'elle n'a pas d'avocat, il lui en est désigné un d'office.<BR>&nbsp;&nbsp;Lorsque le tribunal de la jeunesse est saisi en application de l'article 45.2.a) ou b), ou de l'article 63ter, a) ou c), le ministère public en avise immédiatement le bâtonnier de l'ordre des avocats. Cet avis est, selon le cas, envoyé en même temps que la réquisition la citation ou l'avertissement motivé. Le bâtonnier ou le bureau de consultation et de défense procède à la désignation au plus tard dans les deux jours ouvrables à compter de cet avis.<BR>&nbsp;&nbsp;§ 2. Le ministère public adresse au tribunal de la jeunesse saisi, copie de l'avis informant le bâtonnier de la saisine.<BR>&nbsp;&nbsp;§ 3. Le bâtonnier ou le bureau de consultation et de défense veille, lorsqu'il y a contradiction d'intérêts, à ce que l'intéressé soit assisté par un avocat autre que celui auquel auraient fait appel ses père et mère, tuteurs, ou personnes qui en ont la garde ou qui sont investies d'un droit d'action. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.22' HREF='#Art.21'>Art.</A> <A HREF='#Art.23'> 22</A>. L'article 55 de la même loi, modifié par la loi du 9 avril 1980, est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Art. 55. Lorsqu'une affaire visée au titre II, chapitre III, est portée devant le tribunal de la jeunesse, les parties et leur avocat sont informés du dépôt au greffe du dossier dont ils peuvent prendre connaissance à partir de la notification de la citation.<BR>&nbsp;&nbsp;Les parties et leur avocat peuvent également prendre connaissance du dossier lorsque le ministère public requiert une mesure visée aux articles 52 et 53, ainsi que durant le délai d'appel des ordonnances imposant de telles mesures.<BR>&nbsp;&nbsp;Toutefois, les pièces concernant la personnalité de l'intéressé et le milieu où il vit ne peuvent être communiquées ni à l'intéressé ni à la partie civile. Le dossier complet, y compris ces pièces, doit être mis à la disposition de l'avocat de l'intéressé lorsque ce dernier est partie au procès. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.23' HREF='#Art.22'>Art.</A> <A HREF='#Art.24'> 23</A>. L'article 56, alinéa 1er, de la même loi, est remplacé par ce qui suit :<BR>&nbsp;&nbsp;&quot; Dans les affaires visées au titre II, chapitre III, section première, les mineurs intéressés ne sont pas considérés comme parties au débat, sauf lorsque sont prises à leur égard des mesures prévues à l'article 52. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.24' HREF='#Art.23'>Art.</A> <A HREF='#Art.25'> 24</A>. Un article 56bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 56bis. Le tribunal de la jeunesse doit convoquer la personne de douze ans au moins aux fins d'audition, dans les litiges qui opposent les personnes investies à son égard de l'autorité parentale, lorsque sont débattus des points qui concernent le gouvernement de sa personne, l'administration de ses biens, l'exercice du droit de visite, ou la désignation de la personne visée à l'article 34. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.25' HREF='#Art.24'>Art.</A> <A HREF='#Art.26'> 25</A>. L'article 58, alinéa 1er, de la même loi est complété comme suit :<BR>&nbsp;&nbsp;&quot; sans préjudice des dispositions des articles 52, 52quater, alinéa 6, et 53, alinéa 3. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.26' HREF='#Art.25'>Art.</A> <A HREF='#Art.27'> 26</A>. A l'article 60 de la même loi, moidifié par le décret de la Communauté flamande du 28 mars 1990, sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° A l'alinéa 1er, les mots &quot; ou à la demande des instances compétentes visées à l'article 37, § 2, 4° &quot; sont insérés entre les mots &quot; soit à la demande du ministère public &quot; et les mots &quot; rapporter ou modifier &quot;;<BR>&nbsp;&nbsp;2° A l'alinéa 1er, les mots &quot; à l'exception de la mise à la disposition du gouvernement. &quot; sont supprimés;<BR>&nbsp;&nbsp;3° Cet article est complété comme suit :<BR>&nbsp;&nbsp;&quot; Toute mesure visée à l'article 37, § 2, 3° ou 4°, prise par jugement, doit être réexaminée en vue d'être confirmée, rapportée ou modifiée avant l'expiration du délai d'un an à compter du jour où la décision est devenue définitive. Cette procédure est introduite par le ministère public selon les formes prévues à l'article 45, 2 b) et c).<BR>&nbsp;&nbsp;Les autorités compétentes visées à l'article 37, § 2, 4°, transmettent trimestriellement au tribunal de la jeunesse un rapport d'évaluation relatif à la personne ayant fait l'objet d'une mesure de garde sous un régime éducatif fermé. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.27' HREF='#Art.26'>Art.</A> <A HREF='#Art.28'> 27</A>. L'article 62 de la même loi est remplacé par la disposition suivante :<BR>&nbsp;&nbsp;&quot; Art. 62. Sauf dérogation, les dispositions légales en matière de procédure civile s'appliquent aux procédures visées au titre II, chapitre II, ainsi qu'aux articles 63bis, § 2, et 63ter, alinéa 1er, b), et les dispositions légales concernant les poursuites en matière correctionnelle, aux procédures visées au titre II, chapitre III, et à l'article 63ter, alinéa 1er, a) et c). &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.28' HREF='#Art.27'>Art.</A> <A HREF='#Art.29'> 28</A>. Un article 62bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 62bis. Dans les cas où les dispositions prises en vertu de l'article 59bis, §§ 2bis et 4bis, de la Constitution et de l'article 5, § 1er, II, 6°, de la loi spéciale du 8 août 1980 de réformes institutionnelles, prévoient que l'exécution d'une mesure du tribunal de la jeunesse n'appartient pas au ministère public, une expédition de la décision est adressée à l'autorité administrative qui en est chargée. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.29' HREF='#Art.28'>Art.</A> <A HREF='#Art.30'> 29</A>. Dans l'article 63 de la même loi, modifié par le décret de la Communauté française du 4 mars 1991, sont apportées les modifications suivantes :<BR>&nbsp;&nbsp;1° Aux 1er et 6e alinéas, les mots &quot; puissance partenelle &quot; sont remplacés par les mots &quot; autorité parentale &quot;;<BR>&nbsp;&nbsp;2° Au 1er alinéa, les mots &quot; des articles 37, 39 et 40 &quot; sont remplacés par les mots &quot; des articles 37 et 39. &quot;.<BR><BR>&nbsp;&nbsp;<A NAME='Art.30' HREF='#Art.29'>Art.</A> <A HREF='#Art.31'> 30</A>. Un article 63bis, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 63bis. § 1. Les règles de procédure visées au présent chapitre s'appliquent, à l'exception des articles 45.2. et 46, aux dispositions en matière de protection judiciaire prises par les instances compétentes en vertu de l'article 59bis, §§ 2bis et 4bis, de la Constitution et de l'article 5, § 1er, II, 6°, de la loi spéciale du 8 août 1980 de réformes institutionnelles.<BR>&nbsp;&nbsp;§ 2. Toutefois, lorsque la demande tend à voir homologuer la modification d'une décision prise par le tribunal de la jeunesse, la procédure est la suivante :<BR>&nbsp;&nbsp;a) la demande est adressée par requête de l'autorité administrative compétente au greffe de la juridiction qui a rendu la décision;<BR>&nbsp;&nbsp;b) elle est communiquée immédiatement avec le dossier de la procédure au ministère public, pour avis;<BR>&nbsp;&nbsp;c) dans les trois jours ouvrables à compter du dépôt de la requête, le juge de la jeunesse rend une ordonnance sur avis du ministère public. Cette ordonnance est prise sans convocation des parties. Elle est notifiée aux parties et n'est pas susceptible d'opposition. Le refus d'homologation est susceptible d'appel. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.31' HREF='#Art.30'>Art.</A> <A HREF='#Art.32'> 31</A>. Un article 63ter, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 63ter. Dans les procédures judiciaires visées à l'article 63bis, le tribunal de la jeunesse est saisi :<BR>&nbsp;&nbsp;a) par la réquisition du ministère public en vue d'ordonner ou d'autoriser les mesures prévues par ces organes :<BR>&nbsp;&nbsp;- soit dans le cadre de mesures provisoires avant de statuer au fond,<BR>&nbsp;&nbsp;- soit dans les cas d'urgence;<BR>&nbsp;&nbsp;b) par requête déposée au greffe du tribunal de la jeunesse par la partie intéressée, afin qu'il soit statué sur une contestation relative à une mesure décidée par les instances compétentes, visées à l'article 37, § 2;<BR>&nbsp;&nbsp;c) dans les autres cas, par la comparution volontaire à la suite d'un avertissement motivé donné par le ministère public ou par citation, à la requête du ministère public en vue de statuer au fond, après avoir entendu les parties en leurs moyens.<BR>&nbsp;&nbsp;Dans les cas visés au b), les parties sont convoquées par le greffier à comparaître à l'audience fixée par le juge. La convocation précise l'objet de la demande. Le greffier transmet copie de la requête au ministère public.<BR>&nbsp;&nbsp;Dans les cas visés au c), la citation ou l'avertissement doivent, à peine de nullité, être adressés aux parents, tuteurs ou personnes qui ont la garde du jeune et à lui-même, s'il est âgé de douze ans au moins, ainsi que, le cas échéant, aux autres personnes investies d'un droit d'action. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.32' HREF='#Art.31'>Art.</A> <A HREF='#Art.33'> 32</A>. Un article 63quater, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 63quater. Les articles 52bis, 52ter et 52quater, alinéas 6 et 7, sont mutatis mutandis applicables à toutes les mesures prises suite aux réquisitions visées à l'article 63ter, alinéa 1er, a). &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.33' HREF='#Art.32'>Art.</A> <A HREF='#LNK0001'> 33</A>. Un article 63quinquies, rédigé comme suit, est inséré dans la même loi :<BR>&nbsp;&nbsp;&quot; Art. 63quiquies. Si, dans le cadre des procédures judiciaires visées à l'article 63bis, les mesures prévues le sont pour une durée déterminée, la procédure en prolongation desdites mesures se fait suivant les mêmes formes que celles qui sont prescrites pour la décision initiale. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='LNK0001' HREF='#LNKR0001'>Dispositions diverses.</A><BR><BR>&nbsp;&nbsp;<A NAME='Art.34' HREF='#Art.33'>Art.</A> <A HREF='#Art.35'> 34</A>. La mesure prise en application de l'article 39 de la loi du 8 avril 1965, avant l'entrée en vigueur de l'article 4 de la présente loi, est maintenue à l'égard des personnes visées à l'article 36, 4°, au plus tard jusqu'au jour où ces personnes auront atteint l'âge de dix-huit ans.<BR><BR>&nbsp;&nbsp;<A NAME='Art.35' HREF='#Art.34'>Art.</A> <A HREF='#Art.36'> 35</A>. Dans l'article 1280, alinéa 2, du Code judiciaire, les mots &quot; d'un délégué à la protection de la jeunesse &quot; sont remplacés par les mots &quot; du service social compétent &quot;.<BR><BR>&nbsp;&nbsp;<A NAME='Art.36' HREF='#Art.35'>Art.</A> <A HREF='#Art.37'> 36</A>. L'article 162 du Code des droits d'enregistrement, d'hypothèque et de greffe est complété par un 45°, rédigé comme suit :<BR>&nbsp;&nbsp;&quot; 45° : les actes, jugements et arrêts relatifs aux contestations concernant une mesure de protection sociale. &quot;<BR><BR>&nbsp;&nbsp;<A NAME='Art.37' HREF='#Art.36'>Art.</A> 37. L'article 21, alinéa 4, de la loi du 26 juin 1990 relative à la protection de la jeunesse des malades mentaux est abrogé.<BR>&nbsp;&nbsp;Promulguons la présente loi, ordonnons qu'elle soit revêtue du sceau de l'Etat et publiée par le Moniteur belge.<BR>&nbsp;&nbsp;Donné à Bruxelles, le 2 février 1994.<BR>&nbsp;&nbsp;ALBERT<BR>&nbsp;&nbsp;Par le Roi :<BR>&nbsp;&nbsp;Pour le Ministre de la Justice, absent :<BR>&nbsp;&nbsp;Le Ministre des PME et de l'Agriculture,<BR>&nbsp;&nbsp;A. BOURGEOIS<BR>&nbsp;&nbsp;Scellé du sceau de l'Etat :<BR>&nbsp;&nbsp;Le Ministre de la Justice,<BR>&nbsp;&nbsp;M. WATHELET
+              </div>
+                
+               
+
+
+<div id="list-title-sw_t" class="box">
+<h2 id="sw_t" class="list-title" id="list-link-sw_t">Travaux parlementaires</h2>
+<p class="plain-text">
+&nbsp;&nbsp;&nbsp;Session ordinaire 1992-1993.  Session extraordinaire 1991-1992.  Chambre des représentants.  Documents parlementaires. - Projet de loi, n° 532/1 du 18 juin 1992. Rapport n° 532/9 du 21 janvier 1993 de M. Landuyt. - Amendements n°s 2 à 8, 11, 13 et 14. Texte adopté par la commission de la Justice : 532/10.  Annales parlementaires. - Discussion et adoption, séance du 2 décembre 1993.  Session ordinaire 1992-1993.  Sénat.  Documents parlementaires. - Projet de loi, n° 363/1 du 28 janvier 1993. Rapport n° 633/2 du 30 juin 1993 de M. Pataer. - Amendements n°s 3 et 4. Texte adopté par la commission de la Justice : 633/2, p. 97.  Annales parlementaires. - Discussion et adoption, séance du 20 janvier 1994.
+</p>
+</div>
+<div id="list-title-sw_prev" class="box">
+<h2 id="sw_prev" class="list-title" id="list-link-sw_prev">Préambule</h2>
+<p class="plain-text">
+&nbsp;&nbsp;&nbsp;ALBERT II, Roi des Belges,<br>&nbsp;&nbsp;&nbsp;A tous, présents et à venir, Salut.<br>&nbsp;&nbsp;&nbsp;Les Chambres ont adopté et Nous sanctionnons ce qui suit : 
+</p>
+</div>
+   <div class="links no-print">
+             <div class="links-box">
+               <h2 class="links-title" id="list-link-lien_1">Liens</h2>
+  <a id="link-text" class="links-link" href="https://www.ejustice.just.fgov.be/eli/loi/1994/02/02/1994009284/justel">https://www.ejustice.just.fgov.be/eli/loi/1994/02/02/1994009284/justel</a> 
+              <button class="button button-outlined" id="link-button" data-clipboard-target="#link-text">Copier le lien</button>
+<p>&nbsp;</p>              <a
+                 class="links-link"
+                 href="/mopdf/1994/09/17_1.pdf#Page5   "
+ target=_blank              >
+                 Image de la publication officielle
+               </a>
+             </div>
+ </DIV></DIV>
+          
+             
+              
+    
+        </main>
+      </div>
+    </div>
+     <!-- Dit is sectie voor footer -->
+    <footer class="page__wrapper page__wrapper--footer no-print">
+      <div class="page__section page__section--footer">
+        <nav class="block-footer" aria-label="Footer">
+          <div>
+            <p class="footer-title">Informations générales</p>
+            <ul class="footer-menu">
+              <li class="menu-item">
+                <a href="/img_2024/pdf/GebruiksvoorwaardenFR.pdf" target="_blank">Conditions d'utilisation</a>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <p class="footer-title">Liens utiles</p>
+            <ul class="footer-menu">
+              <li class="menu-item">
+                <a href="https://justitie.belgium.be/fr" target="_blank">SPF Justice</a>
+              </li>
+              <li class="menu-item">
+                <a href="https://www.om-mp.be/fr" target="_blank">Ministère Public</a>
+              </li>
+              <li class="menu-item">
+                <a href="https://www.rechtbanken-tribunaux.be/fr" target="_blank">Cours & tribunaux</a>
+              </li>
+              <li class="menu-item">
+                <a href="https://justice.belgium.be/fr/ordre_judiciaire/cours_et_tribunaux/cour_de_cassation" target="_blank">Cours de cassation</a>
+              </li>
+            </ul>
+          </div>
+        </nav>
+        <div class="copyright">
+           Copyright © 2024 Service Public Fédéral Belge
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>
+
+
+

--- a/tests/parser-anchor.test.ts
+++ b/tests/parser-anchor.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseLawContent } from "../scripts/lib/parser.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Real Justel page for loi 1994009284 (amends loi 8 avril 1965). 37 articles.
+const html = readFileSync(join(__dirname, "fixtures/justel-1994009284.html"), "latin1");
+
+describe("parseLawContent — Justel <a name='Art.N'> anchor segmentation", () => {
+  const law = parseLawContent(html, "1994009284");
+
+  it("segments on the real article anchors, not inline cross-references", () => {
+    // The document has exactly 37 articles. The bug split it into 143 provisions
+    // because the single-quote anchor regex never matched JSDOM's double-quoted
+    // serialization, forcing the over-splitting fallback parser.
+    expect(law.provisions.length).toBe(37);
+  });
+
+  it("captures the full article 1 body (not truncated at \"A l'\")", () => {
+    const art1 = law.provisions.find((p) => p.provision_ref === "art1");
+    expect(art1).toBeDefined();
+    // The bug produced "Article 1. A l'" (15 chars). The real body is long and
+    // contains the cross-reference text inline.
+    expect(art1!.content.length).toBeGreaterThan(200);
+    expect(art1!.content).toContain("article 36bis de la loi du 8 avril 1965");
+    expect(art1!.content).toContain("modifications suivantes");
+  });
+
+  it("does not emit phantom lowercase 'article N' continuation fragments", () => {
+    // Real article bodies start with uppercase "Article N." — a body starting
+    // with LOWERCASE "article N" is a mid-sentence cross-reference fragment that
+    // the over-split produced. Case-sensitive on purpose.
+    const phantom = law.provisions.filter((p) => /^article\s+\d/.test(p.content.trim()));
+    expect(phantom).toHaveLength(0);
+  });
+
+  it("emits each article ref exactly once (no duplicate refs from over-splitting)", () => {
+    const refs = law.provisions.map((p) => p.provision_ref);
+    expect(new Set(refs).size).toBe(refs.length);
+  });
+});
+
+describe("parseLawContent — fallback parser (no anchors) does not over-split", () => {
+  // A document with NO <a name="Art.N"> anchors → the fallback path. Its bodies
+  // contain inline lowercase cross-references ("l'article 5") that must NOT
+  // start a new provision.
+  const noAnchorHtml = `<div id="list-title-3">
+Article 1. Le présent décret règle une matière visée à l'article 5 de la Constitution.
+Article 2. Il modifie l'article 12 et l'article 30 de la loi précédente.
+</div>`;
+
+  it("splits only on real article starts, not inline cross-references", () => {
+    const law = parseLawContent(noAnchorHtml, "test");
+    expect(law.provisions.map((p) => p.provision_ref)).toEqual(["art1", "art2"]);
+    expect(law.provisions[0].content).toContain("l'article 5 de la Constitution");
+    expect(law.provisions[1].content).toContain("l'article 12 et l'article 30");
+  });
+});


### PR DESCRIPTION
## Summary
Root cause of the **~88%-defective Belgian corpus** (P0 in the fleet segmentation-quality backlog, arch-docs #1085). `parseLawContent` reads `textSection.innerHTML`, which JSDOM re-serialises **lower-cased + DOUBLE-quoted** (`<a name="Art.1">`). The anchor regex required **single quotes** (`NAME='Art.1'`) → matched **0 anchors on every doc** → silently forced every document through the over-splitting fallback (splits on every inline "Article N" cross-reference, rampant in amending laws).

On loi 1994009284: **143 provisions instead of 37**, art1 truncated to `"Article 1. A l'"`, phantom lowercase `"article 36bis…"` fragments — reproduced from the real Justel page.

## Fix
- `parseArticles`: quote-agnostic anchor regex `["']Art\.([^"']+)["']` → anchor path runs → **37 provisions, full bodies, no phantoms**.
- `parseArticlesFallback` (defense in depth): split only at line-start capitalised "Article N" (drop case-insensitive split-anywhere) so inline `l'article 5` no longer starts a phantom.

## Tests
Real Justel fixture + synthetic fallback case; 5 new, full repo suite green.

## ⚠️ Deploy
Served corpus stays broken until **re-scrape Justel → rebuild legacy DB → re-extract seed → rebuild chassis → redeploy** (raw HTML isn't cached). The byte-identical `Belgium-law-mcp` copy gets the same patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)